### PR TITLE
Fixed issue when end of line cut off.

### DIFF
--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -105,7 +105,7 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   _accum = [[NSMutableAttributedString alloc] init];
 
   const char* cstr = [string UTF8String];
-  FILE* markdownin = fmemopen((void *)cstr, sizeof(char) * (string.length + 1), "r");
+  FILE* markdownin = fmemopen((void *)cstr, sizeof(char) * (strlen(cstr) + 1), "r");
 
   yyscan_t scanner;
 


### PR DESCRIPTION
Note, that `str.length` might be not equal to `strlen(str.UTF8String)`

This bug also reported by @fonkadelic at #2.
