### PR TITLE
Fixed issue with multi byte special characters

### DIFF
--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -105,7 +105,8 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   _accum = [[NSMutableAttributedString alloc] init];
 
   const char* cstr = [string UTF8String];
-  FILE* markdownin = fmemopen((void *)cstr, sizeof(char) * (string.length + 1), "r");
+  FILE* markdownin = fmemopen((void *)cstr, [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], "r");
+
 
   yyscan_t scanner;
 

--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -107,7 +107,6 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   const char* cstr = [string UTF8String];
   FILE* markdownin = fmemopen((void *)cstr, [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], "r");
 
-
   yyscan_t scanner;
 
   markdownlex_init(&scanner);


### PR DESCRIPTION
If you have characters like "äöüß" in your text it would calculate the length wrong. Use [NSString lengthOfBytesUsingEncoding:NSUTF8StringEncoding], it does everything you need.
