### PR TITLE
Fixed a crash from when NSAttributedStringMarkdownLink was typecast as NSValue

### DIFF
--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -226,10 +226,11 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   [_accum appendAttributedString:[recursiveParser attributedStringFromMarkdownString:string]];
 
   // Adjust the recursive parser's links so that they are offset correctly.
-  for (NSValue* rangeValue in recursiveParser.links) {
-    NSRange range = [rangeValue rangeValue];
+  for (NSAttributedStringMarkdownLink *currentLink in recursiveParser.links) {
+    NSRange range = [currentLink range];
     range.location += _accum.length;
-    [_links addObject:[NSValue valueWithRange:range]];
+    currentLink.range = range;
+    [_links addObject:currentLink];
   }
 }
 


### PR DESCRIPTION
I found a crash in my application today coming from `- (void)recurseOnString:(NSString *)string withFont:(UIFont *)font` and it was coming from line 230, which is `NSRange range = [rangeValue rangeValue];`

I am not exactly sure when this method is called, but it seems that this method thinks `recursiveParser.links` will hold an array of `NSValue`'s, but in my testing it contains an array of `NSAttributedStringMarkdownLink`

Could you let me know if this fix is on the right track or just a band-aid, which doesn't really fix the issue. Thanks!
