### PR TITLE
Added utility method to NSAttributedStringMarkdown to get string with links

### DIFF
--- a/src/NSAttributedStringMarkdownParser.h
+++ b/src/NSAttributedStringMarkdownParser.h
@@ -45,9 +45,6 @@ typedef enum {
 @interface NSAttributedStringMarkdownParser : NSObject <NSCopying>
 
 - (NSAttributedString *)attributedStringFromMarkdownString:(NSString *)string;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
-- (NSAttributedString *)attributedStringWithLinksFromMarkdownString:(NSString *)string;
-#endif
 - (NSArray *)links; // Array of NSAttributedStringMarkdownLink
 
 @property (nonatomic, strong) UINSFont* paragraphFont; // Default: systemFontOfSize:12

--- a/src/NSAttributedStringMarkdownParser.h
+++ b/src/NSAttributedStringMarkdownParser.h
@@ -45,6 +45,9 @@ typedef enum {
 @interface NSAttributedStringMarkdownParser : NSObject <NSCopying>
 
 - (NSAttributedString *)attributedStringFromMarkdownString:(NSString *)string;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+- (NSAttributedString *)attributedStringWithLinksFromMarkdownString:(NSString *)string;
+#endif
 - (NSArray *)links; // Array of NSAttributedStringMarkdownLink
 
 @property (nonatomic, strong) UINSFont* paragraphFont; // Default: systemFontOfSize:12

--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -132,6 +132,20 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   return [_accum copy];
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+
+- (NSAttributedString *)attributedStringWithLinksFromMarkdownString:(NSString *)string {
+    NSMutableAttributedString *result = [[self attributedStringFromMarkdownString:string] mutableCopy];
+    
+    for (NSAttributedStringMarkdownLink *link in _links) {
+        [result addAttribute:NSLinkAttributeName value:link.url range:link.range];
+    }
+    
+    return [result copy];
+}
+
+#endif
+
 - (NSArray *)links {
   return [_links copy];
 }

--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -129,22 +129,26 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
                         range:NSMakeRange(lastBulletStart, _accum.length - lastBulletStart)];
   }
 
+#if TARGET_OS_MAC
+  const BOOL shouldAddLinks = YES;
+#elif __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+  const BOOL shouldAddLinks = (NSLinkAttributeName != nil);
+#endif
+    
+  if (shouldAddLinks) {
+    [self addLinksToAttributedString];
+  }
+
   return [_accum copy];
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
-
-- (NSAttributedString *)attributedStringWithLinksFromMarkdownString:(NSString *)string {
-    NSMutableAttributedString *result = [[self attributedStringFromMarkdownString:string] mutableCopy];
-    
+- (void)addLinksToAttributedString {
+#if TARGET_OS_MAC || __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
     for (NSAttributedStringMarkdownLink *link in _links) {
-        [result addAttribute:NSLinkAttributeName value:link.url range:link.range];
+        [_accum addAttribute:NSLinkAttributeName value:link.url range:link.range];
     }
-    
-    return [result copy];
-}
-
 #endif
+}
 
 - (NSArray *)links {
   return [_links copy];


### PR DESCRIPTION
I don't know if there was a reason to not make this the default behavior, so I figured I could add this as a separate method.

I was confused at first thinking the problem was that I wasn't displaying the links on the attributed string correctly due to some bug in UITextView in iOS 7, so hopefully this will help other people too :)
