### PR TITLE
Add support for defining top attributes for a string. 

### DIFF
--- a/src/NSAttributedStringMarkdownParser.h
+++ b/src/NSAttributedStringMarkdownParser.h
@@ -59,6 +59,9 @@ typedef enum {
 @property (nonatomic, copy) NSString* boldItalicFontName; // Default: Helvetica-BoldOblique
 @property (nonatomic, copy) NSString* codeFontName; // Default: Courier
 
+// common attributes that affect the whole string, can be overriden by the upper attributes
+@property (nonatomic, retain) NSDictionary * topAttributes; // default: nil (do nothing)
+
 - (void)setFont:(UINSFont *)font forHeader:(NSAttributedStringMarkdownParserHeader)header;
 - (UINSFont *)fontForHeader:(NSAttributedStringMarkdownParserHeader)header;
 

--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -66,6 +66,7 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
     self.italicFontName = @"Helvetica-Oblique";
     self.boldItalicFontName = @"Helvetica-BoldOblique";
     self.codeFontName = @"Courier";
+    self.topAttributes = nil;
 
     NSAttributedStringMarkdownParserHeader header = NSAttributedStringMarkdownParserHeader1;
     for (CGFloat headerFontSize = 24; headerFontSize >= 14; headerFontSize -= 2, header++) {
@@ -82,6 +83,7 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   parser.italicFontName = self.italicFontName;
   parser.boldItalicFontName = self.boldItalicFontName;
   parser.codeFontName = self.codeFontName;
+  parser.topAttributes = self.topAttributes;
   for (NSAttributedStringMarkdownParserHeader header = NSAttributedStringMarkdownParserHeader1; header <= NSAttributedStringMarkdownParserHeader6; ++header) {
     [parser setFont:[self fontForHeader:header] forHeader:header];
   }
@@ -258,7 +260,12 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
 - (void)consumeToken:(int)token text:(char*)text {
   NSString* textAsString = [[NSString alloc] initWithCString:text encoding:NSUTF8StringEncoding];
 
-  NSMutableDictionary* attributes = [NSMutableDictionary dictionary];
+  NSMutableDictionary* attributes;
+  if(self.topAttributes != nil) {
+    attributes = [NSMutableDictionary dictionaryWithDictionary:self.topAttributes];
+  } else {
+    attributes = [NSMutableDictionary dictionary];
+  }
   [attributes addEntriesFromDictionary:[self attributesForFont:self.topFont]];
 
   switch (token) {


### PR DESCRIPTION
This change allows to make further changes to the parsed string. Some of them will be overridden by other properties such as `paragraphFont` or `boldFontName`. Usage example:

```
  NSAttributedStringMarkdownParser * parser =[[NSAttributedStringMarkdownParser alloc] init];

  NSMutableParagraphStyle * para = [[NSMutableParagraphStyle alloc] init];
  para.minimumLineHeight = 50;
  parser.topAttributes = @{NSForegroundColorAttributeName : UIColor.greenColor,
                           NSParagraphStyleAttributeName : para,
                           NSStrikethroughStyleAttributeName : @1};
```
