### PR TITLE
Replace ifdef with if for conditional compilation

### DIFF
--- a/src/NSAttributedStringMarkdownParser.m
+++ b/src/NSAttributedStringMarkdownParser.m
@@ -165,7 +165,7 @@ int markdownConsume(char* text, int token, yyscan_t scanner);
   CGFloat firstTabStop = 35.0; // width of your indent
   CGFloat lineSpacing = 0.45;
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
   NSTextAlignment alignment = NSTextAlignmentLeft;
 
   NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];


### PR DESCRIPTION
I had a problem when I use this library on OS X.
And I found that a conditional compilation is not correct: it should use `#if` instead of `#ifdef`. ([more info](http://stackoverflow.com/questions/13255645/use-pragma-ifdef-to-conditionally-compile-the-same-protocol-header-for-both-mac))
